### PR TITLE
Fix build error related to missing header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,7 @@ endif()
 
 #-----------------------------------------------------------------------------
 set(MODULE_INCLUDE_DIRECTORIES
-  ${vtkITK_INCLUDE_DIRS}
-  ${MRMLCore_INCLUDE_DIRS}
-  ${SlicerBaseLogic_SOURCE_DIR}
-  ${SlicerBaseLogic_BINARY_DIR}
+  ${Slicer_Libs_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
@@ -36,12 +33,8 @@ set(MODULE_SRCS
 
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   vtkITK
-  ModuleDescriptionParser
-  MRMLCore
-  SlicerBaseLogic
-  SlicerBaseCLI
-  ITKIO
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently only the variable "Slicer_Libs_INCLUDE_DIRS" is exposed after
finding Slicer. Ideally, variable like vtkITK_INCLUDE_DIRS should also be
available. It would provide more granularity.
See http://www.na-mic.org/Bug/view.php?id=2882

Specify VTK_LIBRARIES and remove extra libraries.
